### PR TITLE
update to use the fixed version by default (you can still access the …

### DIFF
--- a/source/Append.Blazor.Printing/PrintOptions.cs
+++ b/source/Append.Blazor.Printing/PrintOptions.cs
@@ -44,6 +44,6 @@
         /// <summary>
         /// Font size to use when printing. Default is 12px
         /// </summary>
-        public string FontSize { get; set; } = "12px";
+        public string FontSize { get; set; } = "";
     }
 }

--- a/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
+++ b/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
@@ -14,7 +14,7 @@ namespace Append.Blazor.Printing
         public bool? Base64 { get; set; }
         public string TargetStyles { get; set; } = "['*']";
         [JsonPropertyName("font_size")]
-        public string FontSize { get; set; } = "12px";
+        public string FontSize { get; set; } = "";
 
         public PrintOptionsAdapter(PrintOptions options)
         {


### PR DESCRIPTION
…old behavior by setting FontSize="12px" in the PrintOptions)